### PR TITLE
Added Race and Gender Options to Mods

### DIFF
--- a/components/ui/search/Categories.vue
+++ b/components/ui/search/Categories.vue
@@ -1,18 +1,6 @@
 <template>
   <div class="categories">
-    <p v-if="categories.includes('face_mod')">Face Mod</p>
-    <p v-if="categories.includes('hair_mod')">Hair Mod</p>
-    <p v-if="categories.includes('body_mod')">Body Mod</p>
-    <p v-if="categories.includes('skin_mod')">Skin Mod</p>
-    <p v-if="categories.includes('gear_mod')">Gear Mod</p>
-    <p v-if="categories.includes('mount_mod')">Mount Mod</p>
-    <p v-if="categories.includes('minion_mod')">Minion Mod</p>
-    <p v-if="categories.includes('minion_mod')">Furniture Mod</p>
-    <p v-if="categories.includes('racial_scale_mod')">Racial Scale Mod</p>
-    <p v-if="categories.includes('anamnesis_pose')">Anamnesis Pose</p>
-    <p v-if="categories.includes('cmt_pose')">CMT Pose</p>
-    <p v-if="categories.includes('reshade')">Reshade Preset</p>
-    <p v-if="categories.includes('other_mod')">Other Mod</p>
+    <p v-for="item in categories" :key="item">{{ item | categoryLabel }}</p>
   </div>
 </template>
 
@@ -20,6 +8,13 @@
 export default {
   name: 'Categories',
   components: {},
+  filters: {
+    categoryLabel(id) {
+      return id.replace(/_/g, ' ').replace(/(\w)(\w*)/g, function (g0, g1, g2) {
+        return g1.toUpperCase() + g2.toLowerCase()
+      })
+    },
+  },
   props: {
     categories: {
       type: Array,

--- a/pages/mod/_id.vue
+++ b/pages/mod/_id.vue
@@ -199,7 +199,11 @@
         </div>
         <div class="section">
           <h3>Categories</h3>
-          <Categories :categories="mod.categories.concat(mod.loaders)" />
+          <Categories :categories="mod.categories" />
+          <h3>Races</h3>
+          <Categories :categories="mod.races" />
+          <h3>Genders</h3>
+          <Categories :categories="mod.genders" />
         </div>
         <div class="section">
           <h3>Members</h3>

--- a/pages/mod/_id.vue
+++ b/pages/mod/_id.vue
@@ -200,9 +200,9 @@
         <div class="section">
           <h3>Categories</h3>
           <Categories :categories="mod.categories" />
-          <h3>Races</h3>
+          <h3 style="padding-top: 0.7em">Races</h3>
           <Categories :categories="mod.races" />
-          <h3>Genders</h3>
+          <h3 style="padding-top: 0.7em">Genders</h3>
           <Categories :categories="mod.genders" />
         </div>
         <div class="section">

--- a/pages/mod/_id/edit.vue
+++ b/pages/mod/_id/edit.vue
@@ -85,7 +85,7 @@
           placeholder="Choose races"
         />
       </label>
-      <h3>Categories</h3>
+      <h3>Genders</h3>
       <label class="form-label">
         <span> Please select the genders which this mod applied to. </span>
         <multiselect

--- a/pages/mod/_id/edit.vue
+++ b/pages/mod/_id/edit.vue
@@ -177,7 +177,7 @@
           id="tags"
           v-model="mod.tags"
           :options="availableTags"
-          :custom-label="versionLabels"
+          :custom-label="categoryLabels"
           :loading="availableTags.length === 0"
           :multiple="true"
           :searchable="true"
@@ -398,6 +398,8 @@ export default {
           title: this.mod.title,
           description: this.mod.description,
           body: this.mod.body,
+          races: this.mod.races,
+          genders: this.mod.genders,
           categories: this.mod.categories,
           tags: this.mod.tags,
           issues_url: this.mod.issues_url,
@@ -406,7 +408,7 @@ export default {
           license_url: this.license_url,
           discord_url: this.mod.discord_url,
           slug: this.mod.slug,
-          nsfw: this.mod.is_nsfw,
+          is_nsfw: this.mod.is_nsfw,
           donation_urls: this.donationPlatforms.map((it, index) => {
             return {
               id: it.short,

--- a/pages/mod/_id/edit.vue
+++ b/pages/mod/_id/edit.vue
@@ -71,7 +71,7 @@
         <span> Select the character races this mod applies to. </span>
         <multiselect
           id="races"
-          v-model="this.mod.races"
+          v-model="mod.races"
           :options="availableRaces"
           :custom-label="categoryLabels"
           :loading="availableRaces.length === 0"
@@ -90,7 +90,7 @@
         <span> Please select the genders which this mod applied to. </span>
         <multiselect
           id="genders"
-          v-model="this.mod.genders"
+          v-model="mod.genders"
           :options="availableGenders"
           :custom-label="categoryLabels"
           :loading="availableGenders.length === 0"

--- a/pages/mod/_id/edit.vue
+++ b/pages/mod/_id/edit.vue
@@ -438,11 +438,12 @@ export default {
           )
         }
 
-        await this.$router.replace(
+        await this.$router.push(
           `/mod/${this.mod.slug ? this.mod.slug : this.mod.id}`
         )
         await this.$nuxt.refresh()
       } catch (err) {
+        console.log(err)
         this.$notify({
           group: 'main',
           title: 'An Error Occurred',

--- a/pages/mod/_id/edit.vue
+++ b/pages/mod/_id/edit.vue
@@ -29,9 +29,7 @@
     <section class="essentials">
       <h3>Name</h3>
       <label class="form-label">
-        <span>
-          Be creative. TechCraft v7 won't be searchable and won't be clicked on
-        </span>
+        <span> Be creative and descriptive with your mod name </span>
         <input v-model="mod.title" type="text" placeholder="Enter the name" />
       </label>
       <h3>Summary</h3>
@@ -54,7 +52,7 @@
           id="categories"
           v-model="mod.categories"
           :options="availableCategories"
-          :custom-label="versionLabels"
+          :custom-label="categoryLabels"
           :loading="availableCategories.length === 0"
           :multiple="true"
           :searchable="false"
@@ -66,6 +64,45 @@
           :limit="6"
           :hide-selected="true"
           placeholder="Choose categories"
+        />
+      </label>
+      <h3>Races</h3>
+      <label class="form-label">
+        <span> Select the character races this mod applies to. </span>
+        <multiselect
+          id="races"
+          v-model="this.mod.races"
+          :options="availableRaces"
+          :custom-label="categoryLabels"
+          :loading="availableRaces.length === 0"
+          :multiple="true"
+          :searchable="true"
+          :show-no-results="false"
+          :close-on-select="false"
+          :clear-on-select="false"
+          :show-labels="true"
+          :hide-selected="true"
+          placeholder="Choose races"
+        />
+      </label>
+      <h3>Categories</h3>
+      <label class="form-label">
+        <span> Please select the genders which this mod applied to. </span>
+        <multiselect
+          id="genders"
+          v-model="this.mod.genders"
+          :options="availableGenders"
+          :custom-label="categoryLabels"
+          :loading="availableGenders.length === 0"
+          :multiple="true"
+          :searchable="false"
+          :show-no-results="false"
+          :close-on-select="false"
+          :clear-on-select="false"
+          :show-labels="true"
+          :max="1"
+          :hide-selected="true"
+          placeholder="Choose genders"
         />
       </label>
     </section>
@@ -330,6 +367,18 @@ export default {
       iconChanged: false,
 
       sideTypes: ['Required', 'Optional', 'Unsupported'],
+      availableRaces: [
+        'hyur',
+        'elezen',
+        'miqote',
+        'lalafell',
+        'au_ra',
+        'roegadyn',
+        'hrothgar',
+        'viera',
+        'all',
+      ],
+      availableGenders: ['male', 'female', 'unisex'],
     }
   },
   created() {
@@ -344,6 +393,7 @@ export default {
       this.$nuxt.$loading.start()
 
       try {
+        console.log(this.mod)
         const data = {
           title: this.mod.title,
           description: this.mod.description,
@@ -356,7 +406,7 @@ export default {
           license_url: this.license_url,
           discord_url: this.mod.discord_url,
           slug: this.mod.slug,
-          is_nsfw: this.mod.is_nsfw,
+          nsfw: this.mod.is_nsfw,
           donation_urls: this.donationPlatforms.map((it, index) => {
             return {
               id: it.short,
@@ -389,6 +439,7 @@ export default {
         await this.$router.replace(
           `/mod/${this.mod.slug ? this.mod.slug : this.mod.id}`
         )
+        await this.$nuxt.refresh()
       } catch (err) {
         this.$notify({
           group: 'main',
@@ -417,7 +468,7 @@ export default {
         return txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase()
       })
     },
-    versionLabels(id) {
+    categoryLabels(id) {
       if (id) {
         return this.toProperCase(id.replace(/_/g, ' '))
       } else {

--- a/pages/mod/create.vue
+++ b/pages/mod/create.vue
@@ -46,7 +46,7 @@
             id="categories"
             v-model="categories"
             :options="availableCategories"
-            :custom-label="versionLabels"
+            :custom-label="categoryLabels"
             :loading="availableCategories.length === 0"
             :multiple="true"
             :searchable="true"
@@ -57,6 +57,45 @@
             :max="3"
             :hide-selected="true"
             placeholder="Choose categories"
+          />
+        </label>
+        <h3>Races</h3>
+        <label class="form-label">
+          <span> Select the character races this mod applies to. </span>
+          <multiselect
+            id="races"
+            v-model="races"
+            :options="availableRaces"
+            :custom-label="categoryLabels"
+            :loading="availableRaces.length === 0"
+            :multiple="true"
+            :searchable="true"
+            :show-no-results="false"
+            :close-on-select="false"
+            :clear-on-select="false"
+            :show-labels="true"
+            :hide-selected="true"
+            placeholder="Choose races"
+          />
+        </label>
+        <h3>Categories</h3>
+        <label class="form-label">
+          <span> Please select the genders which this mod applied to. </span>
+          <multiselect
+            id="genders"
+            v-model="genders"
+            :options="availableGenders"
+            :custom-label="categoryLabels"
+            :loading="availableGenders.length === 0"
+            :multiple="true"
+            :searchable="false"
+            :show-no-results="false"
+            :close-on-select="false"
+            :clear-on-select="false"
+            :show-labels="true"
+            :max="1"
+            :hide-selected="true"
+            placeholder="Choose genders"
           />
         </label>
       </section>
@@ -322,7 +361,7 @@
             id="tags"
             v-model="tags"
             :options="availableTags"
-            :custom-label="versionLabels"
+            :custom-label="categoryLabels"
             :loading="availableTags.length === 0"
             :multiple="true"
             :searchable="true"
@@ -510,6 +549,19 @@ export default {
       filePost: '',
       filePut: '',
 
+      availableRaces: [
+        'hyur',
+        'elezen',
+        'miqote',
+        'lalafell',
+        'au_ra',
+        'roegadyn',
+        'hrothgar',
+        'viera',
+        'all',
+      ],
+      availableGenders: ['male', 'female', 'unisex'],
+
       cdn: process.env.cdnUrl,
       api_base: process.env.API_URL,
       name: '',
@@ -519,6 +571,8 @@ export default {
       body: '',
       versions: [],
       categories: [],
+      races: [],
+      genders: [],
       tags: [],
       issues_url: null,
       source_url: null,
@@ -591,6 +645,8 @@ export default {
             },
           ],
           categories: this.categories,
+          races: this.races,
+          genders: this.genders,
           tags: this.tags,
           issues_url: this.issues_url,
           source_url: this.source_url,
@@ -658,7 +714,7 @@ export default {
       this.$nuxt.$loading.finish()
     },
 
-    versionLabels(id) {
+    categoryLabels(id) {
       if (id) {
         return this.toProperCase(id.replace(/_/g, ' '))
       } else {


### PR DESCRIPTION
Mods can now be tagged with specific races and genders. The styling of these options match up with the styling of the existing categories. Here is the list of available options:

```js
races: [
  'hyur',
  'elezen',
  'miqote',
  'lalafell',
  'au_ra',
  'roegadyn',
  'hrothgar',
  'viera',
  'all',
]
genders: [
  'male', 
  'female', 
  'unisex'
]
```

New Mod:
> ![image](https://user-images.githubusercontent.com/10831565/121126723-3e854f80-c7ee-11eb-83e1-3b451da026d4.png)

Mod Preview
> ![image](https://user-images.githubusercontent.com/10831565/121126613-13026500-c7ee-11eb-80a1-04fa366fe619.png)

Mod Edit:
> ![image](https://user-images.githubusercontent.com/10831565/121126875-8310eb00-c7ee-11eb-9379-be83f9a31a75.png)