### PR TITLE
Added External Mod Option

### DIFF
--- a/pages/mod/_id/newversion.vue
+++ b/pages/mod/_id/newversion.vue
@@ -49,19 +49,34 @@
             :allow-empty="false"
           />
         </label>
-        <h3>Files</h3>
-        <label>
-          <span>
-            You should upload a single archive file. However, you are allowed to
-            upload multiple
-          </span>
-          <FileInput
-            accept=".zip,.rar,.7z,.7zip,.tar.gz,.ttmp,.ttmp2,.pose,.cmp"
-            multiple
-            prompt="Choose files or drag them here"
-            @change="updateVersionFiles"
-          />
-        </label>
+        <div v-if="this.$router.currentRoute.query['location'] === 'hosted'">
+          <h3>Files</h3>
+          <label>
+            <span>
+              You should upload a single archive file. However, you are allowed
+              to upload multiple
+            </span>
+            <FileInput
+              accept="application/zip,application/gzip,application/vnd.rar,application/x-7z-compressed,text/plain"
+              multiple
+              prompt="Choose files or drag them here"
+              @change="updateVersionFiles"
+            />
+          </label>
+        </div>
+        <div v-if="this.$router.currentRoute.query['location'] === 'external'">
+          <h3>External URL</h3>
+          <label class="form-label">
+            <span>
+              Please provide a link to where you mod is being hosted
+            </span>
+            <input
+              v-model="createdVersion.external_url"
+              type="text"
+              placeholder="Enter a valid URL"
+            />
+          </label>
+        </div>
       </div>
       <div class="changelog">
         <h3>Changelog</h3>

--- a/pages/mod/_id/version/_version/index.vue
+++ b/pages/mod/_id/version/_version/index.vue
@@ -28,6 +28,15 @@
         <span v-if="version.version_type === 'alpha'" class="badge red">
           Alpha
         </span>
+        <span v-if="version.hosting_location === 'hosted'" class="badge green">
+          Hosted
+        </span>
+        <span
+          v-if="version.hosting_location === 'external'"
+          class="badge yellow"
+        >
+          External
+        </span>
         <span>
           {{ version.version_number }}
         </span>

--- a/pages/mod/_id/versions.vue
+++ b/pages/mod/_id/versions.vue
@@ -6,7 +6,9 @@
           <th></th>
           <th>Name</th>
           <th>Version</th>
+          <th>Files</th>
           <th>Status</th>
+          <th>Location</th>
           <th>Downloads</th>
           <th>Date Published</th>
         </tr>
@@ -15,6 +17,7 @@
         <tr v-for="version in versions" :key="version.id">
           <td>
             <a
+              v-if="version.hosting_location === 'hosted'"
               :href="$parent.findPrimary(version).filename"
               class="download"
               :download="$parent.findPrimary(version).filename"
@@ -28,9 +31,17 @@
             >
               <DownloadIcon />
             </a>
+            <a
+              v-if="version.hosting_location === 'external'"
+              :href="version.external_url"
+              class="download"
+            >
+              <DownloadIcon />
+            </a>
           </td>
           <td>
             <nuxt-link
+              v-if="version.hosting_location === 'hosted'"
               :to="
                 '/mod/' +
                 (mod.slug ? mod.slug : mod.id) +
@@ -40,9 +51,16 @@
             >
               {{ version.name ? version.name : version.version_number }}
             </nuxt-link>
+            <a
+              v-if="version.hosting_location === 'external'"
+              :href="version.external_url"
+            >
+              {{ version.name ? version.name : version.version_number }}
+            </a>
           </td>
           <td>
             <nuxt-link
+              v-if="version.hosting_location === 'hosted'"
               :to="
                 '/mod/' +
                 (mod.slug ? mod.slug : mod.id) +
@@ -52,6 +70,26 @@
             >
               {{ version.version_number }}
             </nuxt-link>
+            <a
+              v-if="version.hosting_location === 'external'"
+              :href="version.external_url"
+            >
+              {{ version.version_number }}
+            </a>
+          </td>
+          <td>
+            <nuxt-link
+              v-if="version.hosting_location === 'hosted'"
+              :to="
+                '/mod/' +
+                (mod.slug ? mod.slug : mod.id) +
+                '/version/' +
+                version.id
+              "
+            >
+              {{ version.files.length }}
+            </nuxt-link>
+            <span v-else>Unknown</span>
           </td>
           <td>
             <span v-if="version.version_type === 'release'" class="badge green">
@@ -64,14 +102,45 @@
               Alpha
             </span>
           </td>
-          <td>{{ version.downloads }}</td>
+          <td>
+            <span
+              v-if="version.hosting_location === 'hosted'"
+              class="badge green"
+            >
+              Hosted
+            </span>
+            <span
+              v-if="version.hosting_location === 'external'"
+              class="badge yellow"
+            >
+              External
+            </span>
+          </td>
+          <td>
+            <span v-if="version.hosting_location === 'hosted'">
+              {{ version.downloads }}
+            </span>
+            <span v-else>Unknown</span>
+          </td>
           <td>{{ $dayjs(version.date_published).format('YYYY-MM-DD') }}</td>
         </tr>
       </tbody>
     </table>
     <div class="new-version">
-      <nuxt-link v-if="currentMember" to="newversion" class="button">
+      <nuxt-link
+        v-if="currentMember"
+        :to="{ path: 'newversion', query: { location: 'hosted' } }"
+        class="button"
+        style="margin-right: 1em"
+      >
         New Version
+      </nuxt-link>
+      <nuxt-link
+        v-if="currentMember"
+        :to="{ path: 'newversion', query: { location: 'external' } }"
+        class="button"
+      >
+        New Externally Hosted Version
       </nuxt-link>
     </div>
   </div>
@@ -135,7 +204,7 @@ table {
   td {
     &:first-child {
       text-align: center;
-      width: 7%;
+      width: 5%;
 
       svg {
         color: var(--color-text);
@@ -148,7 +217,7 @@ table {
     }
 
     &:nth-child(2),
-    &:nth-child(5) {
+    &:nth-child(8) {
       padding-left: 0;
       width: 12%;
     }

--- a/pages/mod/create.vue
+++ b/pages/mod/create.vue
@@ -224,11 +224,19 @@
                   Alpha
                 </span>
               </td>
-              <td v-if="version.type === 'hosted'">
-                <span class="badge green"> Hosted </span>
-              </td>
-              <td v-if="version.type === 'external'">
-                <span class="badge yellow"> External </span>
+              <td>
+                <span
+                  v-if="version.hosting_location === 'hosted'"
+                  class="badge green"
+                >
+                  Hosted
+                </span>
+                <span
+                  v-if="version.hosting_location === 'external'"
+                  class="badge yellow"
+                >
+                  External
+                </span>
               </td>
               <td>
                 <button
@@ -320,8 +328,8 @@
                   <FileUpload
                     ref="upload"
                     v-model="versions[currentVersionIndex].files"
-                    extensions="zip,rar,7z,7zip,tar.gz,ttmp,ttmp2"
-                    accept="image/png,image/gif,image/jpeg,image/webp"
+                    extensions="zip,rar,7z,7zip,tar.gz,ttmp,ttmp2,pose,cma"
+                    accept="application/zip,application/gzip,application/vnd.rar,application/x-7z-compressed,text/plain"
                     :multiple="true"
                     :size="1024 * 1024 * 10"
                     :post-action="
@@ -826,7 +834,7 @@ export default {
         release_channel: 'release',
         loaders: [],
         featured: false,
-        type,
+        hosting_location: type,
       }
       switch (type) {
         case 'hosted':


### PR DESCRIPTION
Users are now able to choose between hosting their mods on the repo or having them be hosted externally. Some features such as download counter will be unavailable when using externally hosted mods. For details on the technical implementation, see issue #43. I would request we do not merge this pull request till the backend has been updated to support this feature. As such, I am creating this PR as a draft and will update it when the backend is ready.